### PR TITLE
add escape symbol for psl in insert on update

### DIFF
--- a/src/BulkDB.php
+++ b/src/BulkDB.php
@@ -161,7 +161,12 @@ abstract class BulkDB
 
 		}
 
-		$fill = '' . $efield . ' = ' . $iname . '' . $efield . '' . $ename . '';
+		$escapeSymbol = '';
+		if (preg_match('#PSL#', $ccl)) {
+            $escapeSymbol = '"';
+        }
+
+		$fill = "{$escapeSymbol}{$efield}{$escapeSymbol} = {$iname}{$escapeSymbol}{$efield}{$escapeSymbol}{$ename}";
 		$ufields[] = $fill;
 
 	    }


### PR DESCRIPTION
В запросе "ON CONFLICT ("ext_id") DO UPDATE SET name = EXCLUDED.name, sponsor = EXCLUDED.spon
sor, time_updates = EXCLUDED.time_updates, categories = EXCLUDED.categories, videoLinkingCode = EXCLUDED.videoLinkingCode" игнорировалось обновление поля videoLinkingCode. То есть поля, которые имели название в камелкейсе игнорились. Добавил кавычки для экранирования всех полей в блоке ON CONFLICT DO UPDATE.